### PR TITLE
Add dev script alias for development server

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "start": "tsc && concurrently -k -r \"tsc --watch\" \"wds\"",
+    "dev": "tsc && concurrently -k -r \"tsc --watch\" \"wds\"",
     "build": "rimraf dist && tsc && node --max-old-space-size=4096 node_modules/rollup/dist/bin/rollup -c rollup.config.mjs",
     "start:build": "web-dev-server --root-dir dist --app-index index.html --open",
     "lint": "eslint \"**/*.{js,ts}\" --ignore-path .gitignore",


### PR DESCRIPTION
This PR adds a `dev` script to package.json that serves as an alias for the existing `start` script. Both scripts now execute the same command: `tsc && concurrently -k -r "tsc --watch" "wds"`.

This follows the common convention of providing both `start` and `dev` commands for running the development server.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/fiddle?branchName=stellar-nest&projectId=19e82450d1eb453db00fc431a42bc491)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>19e82450d1eb453db00fc431a42bc491</projectId>-->